### PR TITLE
Fixed casing for mdRef references in CSIP schematron tests

### DIFF
--- a/eark_validator/ipxml/resources/schematron/CSIP/mets_dmdSec_rules.xml
+++ b/eark_validator/ipxml/resources/schematron/CSIP/mets_dmdSec_rules.xml
@@ -8,9 +8,9 @@
       <assert id="CSIP18" role="ERROR" test="@ID">Mandatory, identifier must be unique within the package.</assert>
       <assert id="CSIP19" role="ERROR" test="@CREATED">Mandatory, creation date of the descriptive metadata in this section.</assert>
       <assert id="CSIP20" role="WARN" test="@STATUS">SHOULD be used to indicated the status of the package.</assert>
-      <assert id="CSIP21" role="WARN" test="mets:mdref">SHOULD provide a reference to the descriptive metadata file located in the “metadata” section of the IP..</assert>
+      <assert id="CSIP21" role="WARN" test="mets:mdRef">SHOULD provide a reference to the descriptive metadata file located in the “metadata” section of the IP..</assert>
     </rule>
-    <rule context="/mets:mets/mets:dmdSec/mets:mdref">
+    <rule context="/mets:mets/mets:dmdSec/mets:mdRef">
       <assert id="CSIP22" role="ERROR" test="@LOCTYPE = 'URL'">The locator type is always used with the value “URL” from the vocabulary in the attribute.</assert>
       <assert id="CSIP23" role="ERROR" test="@xlink:type = 'simple'">Attribute used with the value “simple”. Value list is maintained by the xlink standard.</assert>
       <assert id="CSIP24" role="ERROR" test="@xlink:href">The actual location of the resource. This specification recommends recording a URL type filepath in this attribute.</assert>

--- a/eark_validator/ipxml/resources/schematron/CSIP/mets_fileSec_rules.xml
+++ b/eark_validator/ipxml/resources/schematron/CSIP/mets_fileSec_rules.xml
@@ -8,7 +8,7 @@
       <assert id="CSIP59" role="ERROR" test="@ID">An xml:id identifier for the file section used for internal package references.</assert>
       <assert id="CSIP60" role="ERROR" test="mets:fileGrp[@USE = 'Documentation']">All documentation pertaining to the transferred content is placed in one or more file group elements with mets/fileSec/fileGrp/@USE attribute value “Documentation”.</assert>
       <assert id="CSIP113" role="ERROR" test="mets:fileGrp[@USE = 'Schemas']">All XML schemas used in the information package should be referenced from one or more file groups with mets/fileSec/fileGrp/@USE attribute value “Schemas”.</assert>
-      <assert id="CSIP114" role="ERROR" test="mets:fileGrp[@USE = 'Representations']">A pointer to the METS document describing the representation or pointers to the content being transferred must be present in one or more file groups with mets/fileSec/fileGrp/@USE attribute value “Representations”.</assert>
+      <assert id="CSIP114" role="ERROR" test="mets:fileGrp[starts-with(@USE, 'Representations')]">A pointer to the METS document describing the representation or pointers to the content being transferred must be present in one or more file groups with mets/fileSec/fileGrp/@USE attribute value “Representations”.</assert>
     </rule>
     <rule context="/mets:mets/mets:fileSec/mets:fileGrp">
       <report id="CSIP61" role="INFO" test="@ADMID">ADMID attribute used.</report>


### PR DESCRIPTION
Spotted while encoding schematron tests into CSIP METS profile. 