### PR TITLE
Fix/csip88 deprecated assertion message

### DIFF
--- a/eark_validator/ipxml/resources/schematron/CSIP/mets_dmdSec_rules.xml
+++ b/eark_validator/ipxml/resources/schematron/CSIP/mets_dmdSec_rules.xml
@@ -8,9 +8,9 @@
       <assert id="CSIP18" role="ERROR" test="@ID">Mandatory, identifier must be unique within the package.</assert>
       <assert id="CSIP19" role="ERROR" test="@CREATED">Mandatory, creation date of the descriptive metadata in this section.</assert>
       <assert id="CSIP20" role="WARN" test="@STATUS">SHOULD be used to indicated the status of the package.</assert>
-      <assert id="CSIP21" role="WARN" test="mets:mdref">SHOULD provide a reference to the descriptive metadata file located in the “metadata” section of the IP..</assert>
+      <assert id="CSIP21" role="WARN" test="mets:mdRef">SHOULD provide a reference to the descriptive metadata file located in the “metadata” section of the IP..</assert>
     </rule>
-    <rule context="/mets:mets/mets:dmdSec/mets:mdref">
+    <rule context="/mets:mets/mets:dmdSec/mets:mdRef">
       <assert id="CSIP22" role="ERROR" test="@LOCTYPE = 'URL'">The locator type is always used with the value “URL” from the vocabulary in the attribute.</assert>
       <assert id="CSIP23" role="ERROR" test="@xlink:type = 'simple'">Attribute used with the value “simple”. Value list is maintained by the xlink standard.</assert>
       <assert id="CSIP24" role="ERROR" test="@xlink:href">The actual location of the resource. This specification recommends recording a URL type filepath in this attribute.</assert>

--- a/eark_validator/ipxml/resources/schematron/CSIP/mets_structMap_rules.xml
+++ b/eark_validator/ipxml/resources/schematron/CSIP/mets_structMap_rules.xml
@@ -15,7 +15,7 @@
     </rule>
     <rule context="/mets:mets/mets:structMap[@LABEL = 'CSIP']/mets:div">
       <assert id="CSIP85" role="ERROR" test="@ID">An xml:id identifier must be unique within the package.</assert>
-      <assert id="CSIP88" role="ERROR" test="mets:div[@LABEL = 'Metadata']">The package’s top-level structural division div element’s @LABEL attribute value must be identical to the package identifier, i.e. the same value as the mets/@OBJID attribute.</assert>
+      <assert id="CSIP88" role="ERROR" test="mets:div[@LABEL = 'Metadata']">The metadata referenced in the administrative and/or descriptive metadata section is described in the structural map with one sub division.</assert>
       <assert id="CSIP93" role="WARN" test="mets:div[@LABEL = 'Documentation']">The documentation referenced in the file section file groups is described in the structural map with one sub division.</assert>
       <assert id="CSIP97" role="WARN" test="mets:div[@LABEL = 'Schemas']">The schemas referenced in the file section file groups are described in the structural map within a single sub-division.</assert>
       <assert id="CSIP101" role="WARN" test="mets:div[@LABEL = 'Representations']">When no representations are present the content referenced in the file section file group with @USE attribute value “Representations” is described in the structural map as a single sub division.</assert>


### PR DESCRIPTION
Somehow or another the validation message for CSIP88 has been mixed up with that from CSIP86, which has been deprecated. I have replaced it with the requirement text. The schematron is still functional.