### PR TITLE
MAINT: Address Pylint issues

### DIFF
--- a/eark_validator/cli/app.py
+++ b/eark_validator/cli/app.py
@@ -54,7 +54,9 @@ Maintainer: Carl Wilson (OPF), 2020-2024"""
 }
 
 # Create PARSER
-PARSER = argparse.ArgumentParser(prog='eark-validator', description=defaults['description'], epilog=defaults['epilog'])
+PARSER = argparse.ArgumentParser(prog='eark-validator',
+                                 description=defaults['description'],
+                                 epilog=defaults['epilog'])
 
 def parse_command_line():
     """Parse command line arguments."""
@@ -113,8 +115,7 @@ def _validate_ip(path: str) -> Tuple[int, Optional[ValidationReport]]:
     if ret_stat > 0:
         return ret_stat, None
     report = PACKAGES.PackageValidator(checked_path).validation_report
-    print('Path {}, struct result is: {}'.format(checked_path,
-                                                 report.structure.status.value))
+    print(f'Path {checked_path}, struct result is: {report.structure.status.value}')
     # for message in report.structure.messages:
     print(report.model_dump_json())
 
@@ -134,7 +135,7 @@ def _check_path(path: str) -> Tuple[int, Optional[Path]]:
     return 0, Path(path)
 
 def _format_check_path_message(path: Path, message: str) -> str:
-    return 'Processing terminated, path: {} {}.'.format(path, message)
+    return f'Processing terminated, path: {path} {message}.'
 
 # def _test_case_schema_checks():
 if __name__ == '__main__':

--- a/eark_validator/infopacks/package_handler.py
+++ b/eark_validator/infopacks/package_handler.py
@@ -32,7 +32,8 @@ import tempfile
 import zipfile
 from eark_validator.infopacks.manifest import Checksummer
 SUB_MESS_NOT_EXIST = 'Path {} does not exist'
-SUB_MESS_NOT_ARCH = 'Parameter "to_unpack": {} does not reference a file of known archive format (zip or tar).'
+SUB_MESS_NOT_ARCH = 'Parameter "to_unpack": {} does not reference' + \
+                    'a file of known archive format (zip or tar).'
 
 class PackageError(Exception):
     """Exception used to mark validation error when unpacking archive."""
@@ -70,10 +71,10 @@ class PackageHandler():
         if len(children) != 1:
             # Dir unpacks to more than a single folder
             raise PackageError('Unpacking archive yields'
-                                  '{} children.'.format(len(children)))
+                               f'{len(children)} children.')
         if not os.path.isdir(children[0]):
             raise PackageError('Unpacking archive yields'
-                                  'a single file child {}.'.format(children[0]))
+                               f'a single file child {children[0]}.')
         return children[0].absolute()
 
     @staticmethod

--- a/eark_validator/ipxml/namespaces.py
+++ b/eark_validator/ipxml/namespaces.py
@@ -24,29 +24,30 @@
 #
 """
 E-ARK : Information package validation
-        Information Package modules
+        METS/E-ARK namespaces.
 """
 from enum import Enum, unique
 
 @unique
 class Namespaces(str, Enum):
+    """Enumeration of the common namespace prefixes and URIs used in METS and E-ARK."""
     METS = 'http://www.loc.gov/METS/'
     CSIP = 'https://DILCIS.eu/XML/METS/CSIPExtensionMETS'
     SIP = 'https://DILCIS.eu/XML/METS/SIPExtensionMETS'
     XML = 'http://www.w3.org/XML/1998/namespace'
     XHTML = 'http://www.w3.org/1999/xhtml'
     XLINK = 'http://www.w3.org/1999/xlink'
-    PROFILE = 'http://www.loc.gov/METS_Profile/v2',
+    PROFILE = 'http://www.loc.gov/METS_Profile/v2'
     XSI = 'http://www.w3.org/2001/XMLSchema-instance'
 
     def __init__(self, value: str):
-        self._id = value
-        self._qualifier = '{{{}}}'.format(value)
+        self._uri = value
+        self._qualifier = f'{{{value}}}'
         self._prefix = self.name.lower()
 
     @property
-    def id(self) -> str:
-        return self._id
+    def uri(self) -> str:
+        return self._uri
 
     @property
     def prefix(self) -> str:
@@ -60,14 +61,22 @@ class Namespaces(str, Enum):
         return _qualify(self.qualifier, value)
 
     @classmethod
-    def from_id(cls, id: str) -> 'Namespaces':
+    def from_uri(cls, uri: str) -> 'Namespaces':
         for namespace in cls:
-            if namespace.id == id:
+            if namespace.uri == uri:
                 return namespace
         return cls.METS
 
     @classmethod
     def from_prefix(cls, prefix: str) -> 'Namespaces':
+        """Request a namespace instance by prefix.
+
+        Args:
+            prefix (str): the prefix of the namespace to be returned.
+
+        Returns:
+            Namespaces: The namespace instance with the given prefix.
+        """
         search: str = prefix.lower() if prefix else ''
         for namespace in cls:
             if namespace.prefix == search:
@@ -75,4 +84,4 @@ class Namespaces(str, Enum):
         return cls.METS
 
 def _qualify(_ns: str, _v: str) -> str:
-    return '{}{}'.format(_ns, _v)
+    return f'{_ns}{_v}'

--- a/eark_validator/model/manifest.py
+++ b/eark_validator/model/manifest.py
@@ -25,9 +25,9 @@
 #
 from enum import Enum, unique
 from pathlib import Path
-from typing import Annotated, List, Optional
+from typing import List, Optional
 
-from pydantic import BaseModel, StringConstraints
+from pydantic import BaseModel
 
 from .checksum import Checksum
 
@@ -61,4 +61,4 @@ class Manifest(BaseModel):
 
     @property
     def total_size(self) -> int:
-        return sum([entry.size for entry in self.entries])
+        return sum(entry.size for entry in self.entries)

--- a/eark_validator/model/metadata.py
+++ b/eark_validator/model/metadata.py
@@ -23,6 +23,7 @@
 # specific language governing permissions and limitations
 # under the License.
 #
+from enum import Enum
 from pathlib import Path
 from typing import Annotated, List
 
@@ -30,8 +31,13 @@ from pydantic import BaseModel, StringConstraints
 
 from .checksum import Checksum
 
+class EntryType(str, Enum):
+    FILE = 'file'
+    METADATA = 'metadata'
+
 class FileEntry(BaseModel):
     path : Path | str
+    type: EntryType = EntryType.FILE
     size : int = 0
     checksum : Checksum
     mimetype : Annotated[ str, StringConstraints(to_lower=True) ] = 'application/octet-stream'

--- a/eark_validator/model/specifications.py
+++ b/eark_validator/model/specifications.py
@@ -28,7 +28,6 @@ E-ARK : Information Package Validation
         Information Package Package Details type
 """
 from enum import Enum, unique
-from importlib_resources import files
 from typing import Dict, List, Optional
 
 from pydantic import BaseModel, computed_field
@@ -47,7 +46,7 @@ class Level(str, Enum):
     def from_string(level: str) -> 'Level':
         """Convert a string to a Level."""
         for item in Level:
-            if item.value == level or item.name == level:
+            if level in [ item.value, item.name ]:
                 return item
         raise ValueError(f'No Level with value {level}')
 
@@ -87,7 +86,7 @@ class Specification(BaseModel):
     @computed_field
     def requirement_count(self) -> int:
         """Return the number of requirements."""
-        return sum([len(self.requirements[sect]) for sect in self.sections])
+        return sum(len(self.requirements[sect]) for sect in self.sections)
 
     def section_requirements(self, section: Optional[str]=None) -> List[Requirement]:
         """Get the specification requirements, by section if offered."""
@@ -99,14 +98,14 @@ class Specification(BaseModel):
                 requirements += self.requirements[sect]
         return requirements
 
-    def get_requirement_by_id(self, id: str) -> Optional[Requirement]:
+    def get_requirement_by_id(self, req_id: str) -> Optional[Requirement]:
         """Retrieve a requirement by id."""
         for sect in self.sections:
-            req = self.get_requirement_by_sect(id, sect)
+            req = self.get_requirement_by_sect(req_id, sect)
             if req:
                 return req
         return None
 
-    def get_requirement_by_sect(self, id: str, section: str) -> Optional[Requirement]:
+    def get_requirement_by_sect(self, req_id: str, section: str) -> Optional[Requirement]:
         """Retrieve a requirement by id."""
-        return next((req for req in self.requirements[section] if req.id == id), None)
+        return next((req for req in self.requirements[section] if req.id == req_id), None)

--- a/eark_validator/model/validation_report.py
+++ b/eark_validator/model/validation_report.py
@@ -41,19 +41,19 @@ from eark_validator.model.specifications import Level
 @unique
 class Severity(str, Enum):
     """Enum covering information package validation statuses."""
-    Unknown = 'Unknown'
+    UNKNOWN = 'Unknown'
     # Information level, possibly not best practise
-    Information = 'Information'
+    INFORMATION = 'Information'
     # Non-fatal issue that should be corrected
-    Warning = 'Warning'
+    WARNING = 'Warning'
     # Error level message means invalid package
-    Error = 'Error'
+    ERROR = 'Error'
 
     @classmethod
-    def from_id(cls, id: str) -> Optional['Severity']:
+    def from_id(cls, severity_id: str) -> Optional['Severity']:
         """Get the enum from the value."""
         for severity in cls:
-            if severity.name == id or severity.value == id:
+            if severity_id in [ severity.name, severity.value ]:
                 return severity
         return None
 
@@ -64,16 +64,16 @@ class Severity(str, Enum):
         for severity in cls:
             if severity.value.lower().startswith(search):
                 return severity
-        return None
+        raise ValueError(f'No severity found for role: {role}')
 
     @classmethod
     def from_level(cls, level: Level) -> 'Severity':
         """Return the correct test result severity from a Level instance."""
         if level is Level.MUST:
-            return Severity.Error
+            return Severity.ERROR
         if level is Level.SHOULD:
-            return Severity.Warning
-        return Severity.Information
+            return Severity.WARNING
+        return Severity.INFORMATION
 
 class Location(BaseModel):
     """All details of the location of an error."""
@@ -83,34 +83,34 @@ class Location(BaseModel):
 
 class Result(BaseModel):
     rule_id: str | None
-    severity: Severity = Severity.Unknown
+    severity: Severity = Severity.UNKNOWN
     location: Location | None
     message: str | None
 
 @unique
 class StructureStatus(str, Enum):
     """Enum covering information package validation statuses."""
-    Unknown = 'Unknown'
+    UNKNOWN = 'Unknown'
     # Package has basic parse / structure problems and can't be validated
-    NotWellFormed = 'Not Well Formed'
+    NOTWELLFORMED = 'Not Well Formed'
     # Package structure is OK
-    WellFormed = 'Well Formed'
+    WELLFORMED = 'Well Formed'
 
 class StructResults(BaseModel):
-    status: StructureStatus = StructureStatus.Unknown
+    status: StructureStatus = StructureStatus.UNKNOWN
     messages: List[Result] = []
 
     @property
     def errors(self) -> List[Result]:
-        return [m for m in self.messages if m.severity == Severity.Error]
+        return [m for m in self.messages if m.severity == Severity.ERROR]
 
     @property
     def warnings(self) -> List[Result]:
-        return [m for m in self.messages if m.severity == Severity.Warning]
+        return [m for m in self.messages if m.severity == Severity.WARNING]
 
     @property
     def infos(self) -> List[Result]:
-        return [m for m in self.messages if m.severity == Severity.Information]
+        return [m for m in self.messages if m.severity == Severity.INFORMATION]
 
 class MetatdataResults(BaseModel):
     schema_results: List[Result] = []

--- a/eark_validator/packages.py
+++ b/eark_validator/packages.py
@@ -27,7 +27,6 @@ Factory methods for the package classes.
 """
 import os
 from pathlib import Path
-import uuid
 
 from eark_validator import rules as SC
 from eark_validator import structure
@@ -35,34 +34,47 @@ from eark_validator.infopacks.information_package import InformationPackages
 from eark_validator.infopacks.package_handler import PackageHandler
 from eark_validator.mets import MetsValidator
 from eark_validator.model import ValidationReport
-from eark_validator.model import PackageDetails
 from eark_validator.model.package_details import InformationPackage
 from eark_validator.model.validation_report import MetatdataResults
 
-def validate(to_validate: Path, check_metadata: bool=True) -> ValidationReport:
+METS: str = 'METS.xml'
+
+def validate(to_validate: Path) -> ValidationReport:
     """Returns the validation report that results from validating the path
     to_validate as a folder. The method does not validate archive files."""
     is_struct_valid, struct_results = structure.validate(to_validate)
     if not is_struct_valid:
         return ValidationReport.model_validate({'structure': struct_results})
     validator = MetsValidator(str(to_validate))
-    validator.validate_mets('METS.xml')
-    if (not validator.is_valid):
-        metadata: MetatdataResults = MetatdataResults.model_validate({ 'schema_results': validator.validation_errors })
-        return ValidationReport.model_validate({'structure': struct_results, 'metadata': metadata})
+    validator.validate_mets(METS)
+    if not validator.is_valid:
+        metadata: MetatdataResults = MetatdataResults.model_validate({
+            'schema_results': validator.validation_errors
+            })
+        return ValidationReport.model_validate({
+            'structure': struct_results,
+            'metadata': metadata
+            })
     package: InformationPackage = InformationPackages.from_path(to_validate)
     package_type = package.package.oaispackagetype if package.package.oaispackagetype else 'CSIP'
     package_type = 'CSIP' if package_type == 'AIP' else package_type
     profile = SC.ValidationProfile.from_specification(package_type)
-    profile.validate(to_validate.joinpath('METS.xml'))
+    profile.validate(to_validate.joinpath(METS))
     results = profile.get_all_results()
-    metadata: MetatdataResults = MetatdataResults.model_validate({'schema_results': validator.validation_errors, 'schematron_results': results})
-    return ValidationReport.model_validate({'structure': struct_results, 'package': package, 'metadata': metadata})
+    metadata: MetatdataResults = MetatdataResults.model_validate({
+        'schema_results': validator.validation_errors,
+        'schematron_results': results
+        })
+    return ValidationReport.model_validate({
+        'structure': struct_results,
+        'package': package,
+        'metadata': metadata
+        })
 
 class PackageValidator():
     """Class for performing full package validation."""
     _package_handler = PackageHandler()
-    def __init__(self, package_path: Path, check_metadata=True):
+    def __init__(self, package_path: Path):
         self._path : Path = package_path
         self._name: str = os.path.basename(package_path)
         self._report: ValidationReport = None
@@ -71,7 +83,7 @@ class PackageValidator():
             self._to_proc = self._path.absolute()
         elif PackageHandler.is_archive(package_path):
             self._to_proc = self._package_handler.prepare_package(package_path)
-        elif self._name == 'METS.xml':
+        elif self._name == METS:
             mets_path = Path(package_path)
             self._to_proc = mets_path.parent.absolute()
             self._name = os.path.basename(self._to_proc)
@@ -79,7 +91,7 @@ class PackageValidator():
             # If not an archive we can't process
             self._report = _report_from_bad_path(package_path)
             return
-        self._report = validate(self._to_proc, check_metadata)
+        self._report = validate(self._to_proc)
 
     @property
     def original_path(self) -> Path:

--- a/eark_validator/specifications/specification.py
+++ b/eark_validator/specifications/specification.py
@@ -25,7 +25,7 @@
 """Module covering information package structure validation and navigation."""
 import os
 from enum import Enum, unique
-from typing import Generator, List, Optional
+from typing import Optional
 
 from importlib_resources import files
 from lxml import etree as ET
@@ -42,12 +42,12 @@ from eark_validator.specifications.struct_reqs import Level
 class Specifications:
 
     @classmethod
-    def _from_xml_file(cls, xml_file: str, add_struct: bool=False) -> Specification:
+    def _from_xml_file(cls, xml_file: str) -> Specification:
+        """Create a Specification from an XML file."""
         if not os.path.exists(xml_file):
             raise FileNotFoundError(NO_PATH.format(xml_file))
         if not os.path.isfile(xml_file):
             raise ValueError(NOT_FILE.format(xml_file))
-        """Create a Specification from an XML file."""
         tree = ET.parse(xml_file, parser=cls._parser())
         return  cls._from_xml(tree)
 
@@ -159,11 +159,10 @@ class EarkSpecifications(str, Enum):
 
     def __init__(self, value: str):
         self._path = str(files(profiles).joinpath(value + '.xml'))
-        self._specfication = Specifications._from_xml_file(self._path)
-        self._title = value
+        self._specfication = Specifications._from_xml_file(self.path)
 
     @property
-    def id(self) -> str:
+    def spec_id(self) -> str:
         """Get the specification id."""
         return self.name
 
@@ -175,7 +174,7 @@ class EarkSpecifications(str, Enum):
     @property
     def title(self) -> str:
         """Get the specification title."""
-        return self._title
+        return self.value
 
     @property
     def specification(self) -> Specification:
@@ -185,12 +184,12 @@ class EarkSpecifications(str, Enum):
     @property
     def profile(self) -> str:
         """Get the specification profile url."""
-        return 'https://eark{}.dilcis.eu/profile/{}.xml'.format(self.name.lower(), self.value)
+        return f'https://eark{self.name.lower()}.dilcis.eu/profile/{self.value}.xml'
 
     @classmethod
-    def from_id(cls, id: str) -> Optional['EarkSpecifications']:
+    def from_id(cls, spec_id: str) -> Optional['EarkSpecifications']:
         """Get the enum from the value."""
         for spec in cls:
-            if spec.id == id or spec.value == id or spec.profile == id:
+            if spec_id in [ spec.spec_id, spec.value, spec.profile ]:
                 return spec
         return None

--- a/eark_validator/specifications/struct_reqs.py
+++ b/eark_validator/specifications/struct_reqs.py
@@ -51,9 +51,9 @@ REQUIREMENTS = {
           'level': Level.MAY,
           'message': ' '.join([
             'The Information Package MAY be contained in an archive/compressed form,',
-            'e.g. TAR or ZIP, for storage or transfer. The specific format details should be decided',
-            'by the interested parties and documented, for example in a submission agreement or',
-            'statement of access terms.'
+            'e.g. TAR or ZIP, for storage or transfer. The specific format details should be',
+            'decided by the interested parties and documented, for example in a submission',
+            'agreement or statement of access terms.'
           ])
         },
     4: {
@@ -165,8 +165,9 @@ REQUIREMENTS = {
             'We recommend including any supplementary documentation for the package',
             'or a specific representation within the package. Supplementary documentation SHOULD',
             'be placed in a sub-folder called documentation within the Information Package root',
-            'folder and/or the representation folder. Examples of documentation include representation',
-            'information and manuals for the system the data objects have been exported from.'
+            'folder and/or the representation folder. Examples of documentation include',
+            'representation information and manuals for the system the data objects have been',
+            'exported from.'
           ])
         }
 }

--- a/tests/namespaces_test.py
+++ b/tests/namespaces_test.py
@@ -40,16 +40,16 @@ class MetsValidatorTest(unittest.TestCase):
 
     def test_from_id(self):
         for namespace in NS.Namespaces:
-            self.assertEqual(namespace, NS.Namespaces.from_id(namespace.id))
+            self.assertEqual(namespace, NS.Namespaces.from_uri(namespace.uri))
 
     def test_from_bad_id(self):
-        self.assertEqual(NS.Namespaces.METS, NS.Namespaces.from_id('bad'))
-        self.assertEqual(NS.Namespaces.METS, NS.Namespaces.from_id(''))
-        self.assertEqual(NS.Namespaces.METS, NS.Namespaces.from_id(None))
+        self.assertEqual(NS.Namespaces.METS, NS.Namespaces.from_uri('bad'))
+        self.assertEqual(NS.Namespaces.METS, NS.Namespaces.from_uri(''))
+        self.assertEqual(NS.Namespaces.METS, NS.Namespaces.from_uri(None))
 
     def test_qualify(self):
         for namespace in NS.Namespaces:
-            self.assertEqual('{{{}}}file'.format(namespace.id), namespace.qualify('file'))
+            self.assertEqual('{{{}}}file'.format(namespace.uri), namespace.qualify('file'))
 
 
 if __name__ == '__main__':

--- a/tests/schematron_test.py
+++ b/tests/schematron_test.py
@@ -93,8 +93,4 @@ class SchematronTest(unittest.TestCase):
         self.assertFalse(_is_list_valid(SC.TestResults.from_validation_report(self._mets_one_def_rules._schematron.validation_report)))
 
 def _is_list_valid(to_test: List[Result]) -> bool:
-    for result in to_test:
-        if result.severity == Severity.Error:
-            return False
-    return True
-    # return len(list(filter(lambda a: a == Severity.Error, to_test))) < 1
+    return len(list(filter(lambda a: a.severity == Severity.ERROR, to_test))) < 1

--- a/tests/structure_test.py
+++ b/tests/structure_test.py
@@ -31,7 +31,7 @@ from eark_validator import structure as STRUCT
 from eark_validator.model import Severity
 from tests.utils_test import contains_rule_id
 
-EXP_NOT_WELLFORMED = 'Expecting status NotWellFormed, not {}'
+EXP_NOT_WELLFORMED = 'Expecting status NOTWELLFORMED, not {}'
 EXP_WELLFORMED = 'Expecting status WellFormed, not {}'
 EXP_ERRORS = 'Expecting {} errors but found {}'
 class StructValidationTests(unittest.TestCase):
@@ -49,55 +49,55 @@ class StructValidationTests(unittest.TestCase):
         self.assertEqual(len(details.errors), err_count,
                         EXP_ERRORS.format(err_count, len(details.errors)))
         self.assertTrue(contains_rule_id(details.errors, 'CSIPSTR1',
-                                         severity=Severity.Error))
+                                         severity=Severity.ERROR))
 
     def test_str1_package_root_single(self):
         """Dedicated test for package root detection errors."""
         ip_path = Path(os.path.join(self.bad_ip_root, 'single_file.zip'))
         _, details = STRUCT.validate(ip_path)
-        self.assertEqual(details.status, STRUCT.StructureStatus.NotWellFormed,
+        self.assertEqual(details.status, STRUCT.StructureStatus.NOTWELLFORMED,
                         EXP_NOT_WELLFORMED.format(details.status))
         err_count = 1
         self.assertEqual(len(details.errors), err_count,
                         EXP_ERRORS.format(err_count, len(details.errors)))
         self.assertTrue(contains_rule_id(details.errors, 'CSIPSTR1',
-                                         severity=Severity.Error))
+                                         severity=Severity.ERROR))
 
     def test_str1_package_root_multi_dir(self):
         """Dedicated test for package root detection errors."""
         ip_path = Path(os.path.join(self.bad_ip_root, 'multi_dir'))
         _, details = STRUCT.validate(ip_path)
-        self.assertEqual(details.status, STRUCT.StructureStatus.NotWellFormed,
+        self.assertEqual(details.status, STRUCT.StructureStatus.NOTWELLFORMED,
                         EXP_NOT_WELLFORMED.format(details.status))
         err_count = 1
         self.assertEqual(len(details.errors), err_count,
                         EXP_ERRORS.format(err_count, len(details.errors)))
         self.assertTrue(contains_rule_id(details.errors, 'CSIPSTR1',
-                                         severity=Severity.Error))
+                                         severity=Severity.ERROR))
 
     def test_str1_package_root_multi_file(self):
         """Dedicated test for package root detection errors."""
         ip_path = Path(os.path.join(self.bad_ip_root, 'multi_file.zip'))
         _, details = STRUCT.validate(ip_path)
-        self.assertEqual(details.status, STRUCT.StructureStatus.NotWellFormed,
+        self.assertEqual(details.status, STRUCT.StructureStatus.NOTWELLFORMED,
                         EXP_NOT_WELLFORMED.format(details.status))
         err_count = 1
         self.assertEqual(len(details.errors), err_count,
                         EXP_ERRORS.format(err_count, len(details.errors)))
         self.assertTrue(contains_rule_id(details.errors, 'CSIPSTR1',
-                                         severity=Severity.Error))
+                                         severity=Severity.ERROR))
 
     def test_str1_package_root_multi_var(self):
         """Dedicated test for package root detection errors."""
         ip_path = Path(os.path.join(self.bad_ip_root, 'multi_var.zip'))
         _, details = STRUCT.validate(ip_path)
-        self.assertEqual(details.status, STRUCT.StructureStatus.NotWellFormed,
+        self.assertEqual(details.status, STRUCT.StructureStatus.NOTWELLFORMED,
                         EXP_NOT_WELLFORMED.format(details.status))
         err_count = 1
         self.assertEqual(len(details.errors), err_count,
                         EXP_ERRORS.format(err_count, len(details.errors)))
         self.assertTrue(contains_rule_id(details.errors, 'CSIPSTR1',
-                                         severity=Severity.Error))
+                                         severity=Severity.ERROR))
 
     def test_str1_single_file_archive(self):
         """Test a package that's just a compressed single file."""
@@ -108,7 +108,7 @@ class StructValidationTests(unittest.TestCase):
         self.assertEqual(len(details.errors), err_count,
                         EXP_ERRORS.format(err_count, len(details.errors)))
         self.assertTrue(contains_rule_id(details.errors, 'CSIPSTR1',
-                                         severity=Severity.Error))
+                                         severity=Severity.ERROR))
 
     def test_no_messages(self):
         """Test package with no METS.xml file"""
@@ -116,7 +116,7 @@ class StructValidationTests(unittest.TestCase):
                                'no_messages.tar.gz'))
         is_valid, details = STRUCT.validate(ip_path)
         self.assertTrue(is_valid)
-        self.assertEqual(details.status, STRUCT.StructureStatus.WellFormed,
+        self.assertEqual(details.status, STRUCT.StructureStatus.WELLFORMED,
                         EXP_NOT_WELLFORMED.format(details.status))
         self.assertEqual(len(details.messages), 0)
 
@@ -125,44 +125,44 @@ class StructValidationTests(unittest.TestCase):
         ip_path = Path(os.path.join(self.ip_res_root, 'minimal',
                                'minimal_IP_with_schemas.zip'))
         _, details = STRUCT.validate(ip_path)
-        self.assertEqual(details.status, STRUCT.StructureStatus.WellFormed,
+        self.assertEqual(details.status, STRUCT.StructureStatus.WELLFORMED,
                         EXP_WELLFORMED.format(details.status))
         val_warnings = details.warnings
         self.assertEqual(len(val_warnings), 5,
                         'Expecting 2 warnings but found {}'.format(len(val_warnings)))
         self.assertTrue(contains_rule_id(val_warnings, 'CSIPSTR6',
-                                         severity=Severity.Warning))
+                                         severity=Severity.WARNING))
         self.assertTrue(contains_rule_id(val_warnings, 'CSIPSTR7',
-                                         severity=Severity.Warning))
+                                         severity=Severity.WARNING))
         self.assertTrue(contains_rule_id(val_warnings, 'CSIPSTR12',
-                                         severity=Severity.Warning))
+                                         severity=Severity.WARNING))
         self.assertTrue(contains_rule_id(val_warnings, 'CSIPSTR13',
-                                         severity=Severity.Warning))
+                                         severity=Severity.WARNING))
         self.assertTrue(contains_rule_id(val_warnings, 'CSIPSTR16',
-                                         severity=Severity.Warning))
+                                         severity=Severity.WARNING))
 
     def test_str3_package(self):
         """Test minimal STRUCT with schemas, the basic no errors but with warnings package."""
         ip_path = Path(os.path.join(self.ip_res_root, 'unpacked',
                                '733dc055-34be-4260-85c7-5549a7083031'))
         _, details = STRUCT.validate(ip_path)
-        self.assertEqual(details.status, STRUCT.StructureStatus.WellFormed,
+        self.assertEqual(details.status, STRUCT.StructureStatus.WELLFORMED,
                         EXP_WELLFORMED.format(details.status))
         self.assertEqual(len(details.warnings), 1,
                         'Expecting 1 warning but found {}'.format(len(details.warnings)))
         self.assertTrue(contains_rule_id(details.warnings, 'CSIPSTR16',
-                                         severity=Severity.Warning))
+                                         severity=Severity.WARNING))
         self.assertEqual(len(details.infos), 2,
                         'Expecting 2 info messages but found {}'.format(len(details.infos)))
         self.assertTrue(contains_rule_id(details.infos, 'CSIPSTR3',
-                                         severity=Severity.Information))
+                                         severity=Severity.INFORMATION))
 
     def test_str4_nomets(self):
         """Test package with no METS.xml file"""
         ip_path = Path(os.path.join(self.ip_res_root, 'struct',
                                'no_mets.tar.gz'))
         _, details = STRUCT.validate(ip_path)
-        self.assertEqual(details.status, STRUCT.StructureStatus.NotWellFormed,
+        self.assertEqual(details.status, STRUCT.StructureStatus.NOTWELLFORMED,
                         EXP_NOT_WELLFORMED.format(details.status))
         err_count = 1
         self.assertEqual(len(details.messages), err_count,
@@ -174,116 +174,116 @@ class StructValidationTests(unittest.TestCase):
         ip_path = Path(os.path.join(self.ip_res_root, 'struct',
                                'no_md.tar.gz'))
         _, details = STRUCT.validate(ip_path)
-        self.assertEqual(details.status, STRUCT.StructureStatus.WellFormed,
+        self.assertEqual(details.status, STRUCT.StructureStatus.WELLFORMED,
                         EXP_WELLFORMED.format(details.status))
         warn_count = 1
         self.assertEqual(len(details.messages), warn_count,
                         EXP_ERRORS.format(warn_count, len(details.warnings)))
         self.assertTrue(contains_rule_id(details.warnings, 'CSIPSTR5',
-                                         severity=Severity.Warning))
+                                         severity=Severity.WARNING))
 
     def test_str6_nopres(self):
         # test as root
         ip_path = Path(os.path.join(self.ip_res_root, 'struct',
                                'no_pres.tar.gz'))
         _, details = STRUCT.validate(ip_path)
-        self.assertEqual(details.status, STRUCT.StructureStatus.WellFormed,
+        self.assertEqual(details.status, STRUCT.StructureStatus.WELLFORMED,
                         EXP_WELLFORMED.format(details.status))
         warn_count = 1
         self.assertEqual(len(details.messages), warn_count,
                         EXP_ERRORS.format(warn_count, len(details.warnings)))
         self.assertTrue(contains_rule_id(details.warnings, 'CSIPSTR6',
-                                         severity=Severity.Warning))
+                                         severity=Severity.WARNING))
 
     def test_str7_nodesc(self):
         # test as root
         ip_path = Path(os.path.join(self.ip_res_root, 'struct',
                                'no_desc.tar.gz'))
         _, details = STRUCT.validate(ip_path)
-        self.assertEqual(details.status, STRUCT.StructureStatus.WellFormed,
+        self.assertEqual(details.status, STRUCT.StructureStatus.WELLFORMED,
                         EXP_WELLFORMED.format(details.status))
         warn_count = 1
         self.assertEqual(len(details.messages), warn_count,
                         EXP_ERRORS.format(warn_count, len(details.warnings)))
         self.assertTrue(contains_rule_id(details.warnings, 'CSIPSTR7',
-                                         severity=Severity.Warning))
+                                         severity=Severity.WARNING))
 
     def test_str8_noother(self):
         # test as root
         ip_path = Path(os.path.join(self.ip_res_root, 'struct',
                                'no_other.tar.gz'))
         _, details = STRUCT.validate(ip_path)
-        self.assertEqual(details.status, STRUCT.StructureStatus.WellFormed,
+        self.assertEqual(details.status, STRUCT.StructureStatus.WELLFORMED,
                         EXP_WELLFORMED.format(details.status))
         warn_count = 1
         self.assertEqual(len(details.messages), warn_count,
                         EXP_ERRORS.format(warn_count, len(details.infos)))
         self.assertTrue(contains_rule_id(details.infos, 'CSIPSTR8',
-                                         severity=Severity.Information))
+                                         severity=Severity.INFORMATION))
 
     def test_str9_noreps(self):
         ip_path = Path(os.path.join(self.ip_res_root, 'struct',
                                'no_reps.tar.gz'))
         _, details = STRUCT.validate(ip_path)
-        self.assertEqual(details.status, STRUCT.StructureStatus.WellFormed,
+        self.assertEqual(details.status, STRUCT.StructureStatus.WELLFORMED,
                         EXP_WELLFORMED.format(details.status))
         val_warnings = details.warnings
         err_count = 1
         self.assertEqual(len(val_warnings), err_count,
                         EXP_ERRORS.format(err_count, len(val_warnings)))
         self.assertTrue(contains_rule_id(val_warnings, 'CSIPSTR9',
-                                         severity=Severity.Warning))
+                                         severity=Severity.WARNING))
 
     def test_str10_emptyreps(self):
         ip_path = Path(os.path.join(self.ip_res_root, 'struct',
                                'empty_reps.tar.gz'))
         _, details = STRUCT.validate(ip_path)
-        self.assertEqual(details.status, STRUCT.StructureStatus.WellFormed,
+        self.assertEqual(details.status, STRUCT.StructureStatus.WELLFORMED,
                         EXP_WELLFORMED.format(details.status))
         err_count = 1
         self.assertEqual(len(details.messages), err_count,
                         EXP_ERRORS.format(err_count, len(details.warnings)))
         self.assertTrue(contains_rule_id(details.warnings, 'CSIPSTR10',
-                                         severity=Severity.Warning))
+                                         severity=Severity.WARNING))
 
     def test_str11_nodata(self):
         # test as root
         ip_path = Path(os.path.join(self.ip_res_root, 'struct',
                                'no_data.tar.gz'))
         _, details = STRUCT.validate(ip_path)
-        self.assertEqual(details.status, STRUCT.StructureStatus.WellFormed,
+        self.assertEqual(details.status, STRUCT.StructureStatus.WELLFORMED,
                         EXP_WELLFORMED.format(details.status))
         warn_count = 1
         self.assertEqual(len(details.messages), warn_count,
                         EXP_ERRORS.format(warn_count, len(details.warnings)))
         self.assertTrue(contains_rule_id(details.warnings, 'CSIPSTR11',
-                                         severity=Severity.Warning))
+                                         severity=Severity.WARNING))
 
     def test_str12_norepmets(self):
         # test as root
         ip_path = Path(os.path.join(self.ip_res_root, 'struct',
                                'no_repmets.tar.gz'))
         _, details = STRUCT.validate(ip_path)
-        self.assertEqual(details.status, STRUCT.StructureStatus.WellFormed,
+        self.assertEqual(details.status, STRUCT.StructureStatus.WELLFORMED,
                         EXP_WELLFORMED.format(details.status))
         warn_count = 1
         self.assertEqual(len(details.messages), warn_count,
                         EXP_ERRORS.format(warn_count, len(details.warnings)))
         self.assertTrue(contains_rule_id(details.warnings, 'CSIPSTR12',
-                                         severity=Severity.Warning))
+                                         severity=Severity.WARNING))
 
     def test_str13_norepmd(self):
         # test as root
         ip_path = Path(os.path.join(self.ip_res_root, 'struct',
                                'no_repmd.tar.gz'))
         _, details = STRUCT.validate(ip_path)
-        self.assertEqual(details.status, STRUCT.StructureStatus.WellFormed,
+        self.assertEqual(details.status, STRUCT.StructureStatus.WELLFORMED,
                         EXP_WELLFORMED.format(details.status))
         warn_count = 1
         self.assertEqual(len(details.messages), warn_count,
                         EXP_ERRORS.format(warn_count, len(details.warnings)))
         self.assertTrue(contains_rule_id(details.warnings, 'CSIPSTR13',
-                                         severity=Severity.Warning))
+                                         severity=Severity.WARNING))
 
     def test_str15_noschema(self):
         # test as root
@@ -291,26 +291,26 @@ class StructValidationTests(unittest.TestCase):
                                'no_schemas.tar.gz'))
         _, details = STRUCT.validate(ip_path)
 
-        self.assertEqual(details.status, STRUCT.StructureStatus.WellFormed,
+        self.assertEqual(details.status, STRUCT.StructureStatus.WELLFORMED,
                         EXP_WELLFORMED.format(details.status))
         warn_count = 1
         self.assertEqual(len(details.messages), warn_count,
                         EXP_ERRORS.format(warn_count, len(details.warnings)))
         self.assertTrue(contains_rule_id(details.warnings, 'CSIPSTR15',
-                                         severity=Severity.Warning))
+                                         severity=Severity.WARNING))
 
     def test_str16_nodocs(self):
         # test as root
         ip_path = Path(os.path.join(self.ip_res_root, 'struct',
                                'no_docs.tar.gz'))
         _, details = STRUCT.validate(ip_path)
-        self.assertEqual(details.status, STRUCT.StructureStatus.WellFormed,
+        self.assertEqual(details.status, STRUCT.StructureStatus.WELLFORMED,
                         EXP_WELLFORMED.format(details.status))
         warn_count = 1
         self.assertEqual(len(details.messages), warn_count,
                         EXP_ERRORS.format(warn_count, len(details.warnings)))
         self.assertTrue(contains_rule_id(details.warnings, 'CSIPSTR16',
-                                         severity=Severity.Warning))
+                                         severity=Severity.WARNING))
 
     def test_get_reps(self):
         ip_path = Path(os.path.join(self.ip_res_root, 'struct',

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -24,7 +24,7 @@
 #
 """Module that holds common utilities for unit testing."""
 from eark_validator.model import Severity
-def contains_rule_id(error_list, rule_id, severity=Severity.Error):
+def contains_rule_id(error_list, rule_id, severity=Severity.ERROR):
     """Check that a particular error with specified severity is present in a list
     of errors."""
     for val_error in error_list:


### PR DESCRIPTION
- no functional changes;
- used of `f''` string rather than `str.format()`;
- better used of constants for strings, though not perfect;
- better code documentation, though far from perfect;
- test adjustments to match, though no pylint on test code;
- use of generation expressions rather than list comprehensions; and
- various occurrences of minor issues:
  - unused variables/parameters/imports;
  - overlong lines; and
  - redundant braces and else statements.