### PR TITLE
REFACT: StructuralRequirment -> Requirement

### DIFF
--- a/eark_validator/ipxml/schematron.py
+++ b/eark_validator/ipxml/schematron.py
@@ -48,7 +48,7 @@ class SchematronRuleset():
         try:
             self._schematron = Schematron(file=self._path, store_schematron=True, store_report=True)
         except (ET.SchematronParseError, KeyError) as ex:
-            ex_mess = ex.__doc__ if isinstance(ex, KeyError) else ex.error_log.last_error.message
+            ex_mess = ex.__doc__ if isinstance(ex, KeyError) else ex.error_log.last_error.message # pylint: disable=E1101
             subject = 'Schematron' if isinstance(ex, ET.SchematronParseError) else 'XML'
             raise ValueError(f'Rules file is not valid {subject}: {sch_path}. {ex_mess}') from ex
 

--- a/eark_validator/model/__init__.py
+++ b/eark_validator/model/__init__.py
@@ -25,7 +25,7 @@
 #
 """
 E-ARK : Information Package Validation
-        Information Package API model types
+        Information Package model types and constants.
 """
 # import models into model package
 from .checksum import Checksum, ChecksumAlg

--- a/eark_validator/model/checksum.py
+++ b/eark_validator/model/checksum.py
@@ -62,7 +62,7 @@ class ChecksumAlg(str, Enum):
         for algorithm in ChecksumAlg:
             if search_value in [ algorithm.name, algorithm.value ]:
                 return algorithm
-        return None
+        raise ValueError(f'No ChecksumAlg with id: {value}')
 
     @classmethod
     def get_implementation(cls, algorithm: 'ChecksumAlg' = SHA1):

--- a/eark_validator/model/constants.py
+++ b/eark_validator/model/constants.py
@@ -23,33 +23,19 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-from enum import Enum
-from pathlib import Path
-from typing import Annotated, List
-
-from pydantic import BaseModel, StringConstraints
-
-from .checksum import Checksum
-from .constants import MIME_DEFAULT
-
-class EntryType(str, Enum):
-    FILE = 'file'
-    METADATA = 'metadata'
-
-class FileEntry(BaseModel):
-    path : Path | str
-    type: EntryType = EntryType.FILE
-    size : int = 0
-    checksum : Checksum
-    mimetype : Annotated[ str, StringConstraints(to_lower=True) ] = MIME_DEFAULT
-
-class MetsRoot(BaseModel):
-    namespaces: dict[str, str] = {}
-    objid: str = ''
-    label: str= ''
-    type: str = ''
-    profile: str = ''
-
-class MetsFile(BaseModel):
-    root: MetsRoot = MetsRoot()
-    file_entries: List[FileEntry] = []
+"""
+    E-ARK : Information Package Validation Model constants
+    Constant values for the model package
+"""
+METS = 'mets'
+METS_FILE = 'METS.xml'
+MIME_DEFAULT = 'application/octet-stream'
+MAY = 'MAY'
+SHOULD = 'SHOULD'
+MUST = 'MUST'
+UNKNOWN = 'Unknown'
+INFORMATION = 'Information'
+WARNING = 'Warning'
+ERROR = 'Error'
+NOTWELLFORMED = 'Not Well Formed'
+WELLFORMED = 'Well Formed'

--- a/eark_validator/model/manifest.py
+++ b/eark_validator/model/manifest.py
@@ -30,6 +30,7 @@ from typing import List, Optional
 from pydantic import BaseModel
 
 from .checksum import Checksum
+from .constants import METS # pylint: disable=W0611
 
 class ManifestEntry(BaseModel):
     path : Path | str
@@ -45,7 +46,7 @@ class SourceType(str, Enum):
     """Enum covering information package validation statuses."""
     UNKNOWN = 'UNKNOWN'
     # Information level, possibly not best practise
-    METS = 'METS'
+    METS = METS.upper()
     # Non-fatal issue that should be corrected
     PACKAGE = 'PACKAGE'
 

--- a/eark_validator/model/specifications.py
+++ b/eark_validator/model/specifications.py
@@ -32,15 +32,16 @@ from typing import Dict, List, Optional
 
 from pydantic import BaseModel, computed_field
 
+from .constants import MAY, SHOULD, MUST
 
 @unique
 class Level(str, Enum):
     """Enum covering information package validation statuses."""
-    MAY = 'MAY'
+    MAY = MAY
     # Package has basic parse / structure problems and can't be validated
-    SHOULD = 'SHOULD'
+    SHOULD = SHOULD
     # Package structure is OK
-    MUST = 'MUST'
+    MUST = MUST
 
     @staticmethod
     def from_string(level: str) -> 'Level':
@@ -50,19 +51,11 @@ class Level(str, Enum):
                 return item
         raise ValueError(f'No Level with value {level}')
 
-class StructuralRequirement(BaseModel):
-    """Encapsulates a structural requirement."""
-    id: str
-    level: Level = Level.MUST
-    message: Optional[str] = None
-
 class Requirement(BaseModel):
     """Encapsulates a requirement."""
     id: str
-    name: str
     level: Level = Level.MUST
-    xpath: Optional[str] = None
-    cardinality: Optional[str] = None
+    message: Optional[str] = None
 
 class Specification(BaseModel):
     """Stores the vital facts and figures an IP specification."""
@@ -70,7 +63,7 @@ class Specification(BaseModel):
     url: Optional[str] = None
     version: str
     date: str
-    structural_requirements: List[StructuralRequirement] = []
+    structural_requirements: List[Requirement] = []
     requirements: Dict[str, List[Requirement]] = {}
 
     @computed_field

--- a/eark_validator/model/validation_report.py
+++ b/eark_validator/model/validation_report.py
@@ -35,19 +35,21 @@ import uuid
 
 from pydantic import BaseModel
 
-from eark_validator.model.package_details import InformationPackage
-from eark_validator.model.specifications import Level
+from .package_details import InformationPackage
+from .specifications import Level
+from .constants import (
+    UNKNOWN, INFORMATION, WARNING, ERROR, WELLFORMED, NOTWELLFORMED)
 
 @unique
 class Severity(str, Enum):
     """Enum covering information package validation statuses."""
-    UNKNOWN = 'Unknown'
+    UNKNOWN = UNKNOWN
     # Information level, possibly not best practise
-    INFORMATION = 'Information'
+    INFORMATION = INFORMATION
     # Non-fatal issue that should be corrected
-    WARNING = 'Warning'
+    WARNING = WARNING
     # Error level message means invalid package
-    ERROR = 'Error'
+    ERROR = ERROR
 
     @classmethod
     def from_id(cls, severity_id: str) -> Optional['Severity']:
@@ -90,11 +92,11 @@ class Result(BaseModel):
 @unique
 class StructureStatus(str, Enum):
     """Enum covering information package validation statuses."""
-    UNKNOWN = 'Unknown'
+    UNKNOWN = UNKNOWN
     # Package has basic parse / structure problems and can't be validated
-    NOTWELLFORMED = 'Not Well Formed'
+    NOTWELLFORMED = NOTWELLFORMED
     # Package structure is OK
-    WELLFORMED = 'Well Formed'
+    WELLFORMED = WELLFORMED
 
 class StructResults(BaseModel):
     status: StructureStatus = StructureStatus.UNKNOWN

--- a/eark_validator/specifications/specification.py
+++ b/eark_validator/specifications/specification.py
@@ -34,7 +34,7 @@ from eark_validator.const import NO_PATH, NOT_FILE
 from eark_validator.ipxml.namespaces import Namespaces
 from eark_validator.ipxml.resources import profiles
 from eark_validator.ipxml.schema import METS_PROF_SCHEMA
-from eark_validator.model.specifications import Requirement, Specification, StructuralRequirement
+from eark_validator.model.specifications import Requirement, Specification
 from eark_validator.specifications.struct_reqs import REQUIREMENTS
 from eark_validator.specifications.struct_reqs import Level
 
@@ -126,7 +126,7 @@ class Requirements():
 
 class StructuralRequirements():
     @staticmethod
-    def from_rule_no(rule_no: int) -> StructuralRequirement:
+    def from_rule_no(rule_no: int) -> Requirement:
         """Create an StructuralRequirement from a numerical rule id and a sub_message."""
         item = REQUIREMENTS.get(rule_no)
         if not item:
@@ -134,21 +134,20 @@ class StructuralRequirements():
         return StructuralRequirements.from_dictionary(item)
 
     @staticmethod
-    def from_dictionary(item: dict[str, str]) -> StructuralRequirement:
+    def from_dictionary(item: dict[str, str]) -> Requirement:
         """Create an StructuralRequirement from dictionary item and a sub_message."""
-        return StructuralRequirement.model_validate({
+        return Requirement.model_validate({
                 'id': item.get('id'),
                 'level': item.get('level'),
                 'message': item.get('message')
             })
 
     @staticmethod
-    def get_requirements() -> list[StructuralRequirement]:
+    def get_requirements() -> list[Requirement]:
         reqs = []
         for req in REQUIREMENTS.values():
-            reqs.append(StructuralRequirement.model_validate(req))
+            reqs.append(Requirement.model_validate(req))
         return reqs
-
 
 @unique
 class EarkSpecifications(str, Enum):

--- a/eark_validator/structure.py
+++ b/eark_validator/structure.py
@@ -151,7 +151,7 @@ class StructureChecker():
 
     def get_representations(self) -> List[Representation]:
         reps: List[Representation] = []
-        for rep in self.representations.keys():
+        for rep in self.representations.keys(): # pylint: disable=C0201
             reps.append(Representation.model_validate({ 'name': rep }))
         return reps
 

--- a/tests/manifests_test.py
+++ b/tests/manifests_test.py
@@ -85,8 +85,8 @@ class ChecksumTest(unittest.TestCase):
 
     def test_missing_alg(self):
         """Test that a missing algorithm returns None."""
-        alg = ChecksumAlg.from_string('NOT_AN_ALGORITHM')
-        self.assertIsNone(alg)
+        with self.assertRaises(ValueError):
+            ChecksumAlg.from_string('NOT_AN_ALGORITHM')
 
     def test_missing_implementation(self):
         """Test that a missing algorithm returns None."""

--- a/tests/specification_test.py
+++ b/tests/specification_test.py
@@ -29,9 +29,12 @@ import unittest
 from lxml import etree as ET
 
 from importlib_resources import files
-from eark_validator.model.specifications import Specification, StructuralRequirement
+from eark_validator.model.specifications import Specification, Requirement
 
-from eark_validator.specifications.specification import EarkSpecifications, Specifications, StructuralRequirements
+from eark_validator.specifications.specification import (
+    EarkSpecifications,
+    Specifications,
+    StructuralRequirements)
 import tests.resources.xml as XML
 from eark_validator.ipxml.resources import profiles
 
@@ -68,7 +71,7 @@ class StructuralRequirementsTest(unittest.TestCase):
             StructuralRequirements.from_rule_no('1')
 
     def test_from_rule_no(self):
-        req: StructuralRequirement = StructuralRequirements.from_rule_no(1)
+        req: Requirement = StructuralRequirements.from_rule_no(1)
         self.assertEqual(req.id, 'CSIPSTR1')
 
 class EarkSpecificationsTest(unittest.TestCase):


### PR DESCRIPTION
- removed `StructuralRequirment` class so there is now only a singe `Requirement` class;
- disabled the few legitimate pylint exceptions;
- `ValueError` rather than `None` return for `ChecksumAlg.from_string()`; and
- refactored model string constants to a single `model.constants` module.