### PR TITLE
FEAT: Always validating package against CSIP schematron ruleset

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,4 +199,4 @@ pip install --editable ".[testing]"
 
 ### Running tests
 
-You can run unit tests from the project root: `pytest ./tests/`, or generate test coverage figures by: `pytest --cov=ip_validation ./tests/`. If you want to see which parts of your code aren't tested then: `pytest --cov=ip_validation --cov-report=html ./tests/`. After this you can open the file [`<projectRoot>/htmlcov/index.html`](./htmlcov/index.html) in your browser and survey the gory details.
+You can run unit tests from the project root: `pytest ./tests/`, or generate test coverage figures by: `pytest --cov=eark_validator ./tests/`. If you want to see which parts of your code aren't tested then: `pytest --cov=eark_validator --cov-report=html ./tests/`. After this you can open the file [`<projectRoot>/htmlcov/index.html`](./htmlcov/index.html) in your browser and survey the gory details.

--- a/eark_validator/packages.py
+++ b/eark_validator/packages.py
@@ -56,13 +56,13 @@ def validate(to_validate: Path) -> ValidationReport:
             'metadata': metadata
             })
     
-    csip_profile = SC.ValidationProfile.from_specification('CSIP')
+    csip_profile = SC.ValidationProfile.from_specification_name('CSIP')
     csip_profile.validate(to_validate.joinpath(METS))
     results = csip_profile.get_all_results()
 
     package: InformationPackage = InformationPackages.from_path(to_validate)
     if package.package.oaispackagetype in ['SIP', 'DIP']:
-        profile = SC.ValidationProfile.from_specification(package.package.oaispackagetype)
+        profile = SC.ValidationProfile.from_specification_name(package.package.oaispackagetype)
         profile.validate(to_validate.joinpath(METS))
         results.extend(profile.get_all_results())
 

--- a/eark_validator/packages.py
+++ b/eark_validator/packages.py
@@ -36,6 +36,7 @@ from eark_validator.mets import MetsValidator
 from eark_validator.model import ValidationReport
 from eark_validator.model.package_details import InformationPackage
 from eark_validator.model.validation_report import MetatdataResults
+from eark_validator.specifications.specification import EarkSpecifications
 
 METS: str = 'METS.xml'
 
@@ -56,13 +57,13 @@ def validate(to_validate: Path) -> ValidationReport:
             'metadata': metadata
             })
     
-    csip_profile = SC.ValidationProfile.from_specification_name('CSIP')
+    csip_profile = SC.ValidationProfile.from_specification(EarkSpecifications.CSIP.specification)
     csip_profile.validate(to_validate.joinpath(METS))
     results = csip_profile.get_all_results()
 
     package: InformationPackage = InformationPackages.from_path(to_validate)
     if package.package.oaispackagetype in ['SIP', 'DIP']:
-        profile = SC.ValidationProfile.from_specification_name(package.package.oaispackagetype)
+        profile = SC.ValidationProfile.from_specification(package.package.oaispackagetype)
         profile.validate(to_validate.joinpath(METS))
         results.extend(profile.get_all_results())
 

--- a/eark_validator/packages.py
+++ b/eark_validator/packages.py
@@ -56,7 +56,7 @@ def validate(to_validate: Path) -> ValidationReport:
             'structure': struct_results,
             'metadata': metadata
             })
-    
+
     csip_profile = SC.ValidationProfile.from_specification(EarkSpecifications.CSIP.specification)
     csip_profile.validate(to_validate.joinpath(METS))
     results = csip_profile.get_all_results()

--- a/eark_validator/packages.py
+++ b/eark_validator/packages.py
@@ -55,12 +55,17 @@ def validate(to_validate: Path) -> ValidationReport:
             'structure': struct_results,
             'metadata': metadata
             })
+    
+    csip_profile = SC.ValidationProfile.from_specification('CSIP')
+    csip_profile.validate(to_validate.joinpath(METS))
+    results = csip_profile.get_all_results()
+
     package: InformationPackage = InformationPackages.from_path(to_validate)
-    package_type = package.package.oaispackagetype if package.package.oaispackagetype else 'CSIP'
-    package_type = 'CSIP' if package_type == 'AIP' else package_type
-    profile = SC.ValidationProfile.from_specification(package_type)
-    profile.validate(to_validate.joinpath(METS))
-    results = profile.get_all_results()
+    if package.package.oaispackagetype in ['SIP', 'DIP']:
+        profile = SC.ValidationProfile.from_specification(package.package.oaispackagetype)
+        profile.validate(to_validate.joinpath(METS))
+        results.extend(profile.get_all_results())
+
     metadata: MetatdataResults = MetatdataResults.model_validate({
         'schema_results': validator.validation_errors,
         'schematron_results': results

--- a/eark_validator/rules.py
+++ b/eark_validator/rules.py
@@ -99,7 +99,7 @@ class ValidationProfile():
         return self.results.get(name)
 
     @classmethod
-    def from_specification(cls, specification: Specification) -> 'ValidationProfile':
+    def from_specification_name(cls, specification: str) -> 'ValidationProfile':
         """Create a validation profile from a specification."""
         if isinstance(specification, str):
             specification = EarkSpecifications.from_id(specification)

--- a/eark_validator/rules.py
+++ b/eark_validator/rules.py
@@ -99,7 +99,7 @@ class ValidationProfile():
         return self.results.get(name)
 
     @classmethod
-    def from_specification_name(cls, specification: str) -> 'ValidationProfile':
+    def from_specification(cls, specification: str | EarkSpecifications | Specification) -> 'ValidationProfile':
         """Create a validation profile from a specification."""
         if isinstance(specification, str):
             specification = EarkSpecifications.from_id(specification)

--- a/tests/rules_test.py
+++ b/tests/rules_test.py
@@ -172,6 +172,14 @@ class ValidationProfileTest(unittest.TestCase):
         with self.assertRaises(ValueError):
             SC.ValidationProfile.from_specification('BAD')
 
+    def test_unimplemented_specifications(self):
+        with self.assertRaises(ValueError):
+            SC.ValidationProfile.from_specification('AIP')
+        with self.assertRaises(ValueError):
+            SC.ValidationProfile.from_specification('AIU')
+        with self.assertRaises(ValueError):
+            SC.ValidationProfile.from_specification('AIC')
+
     def test_valid(self):
         profile = SC.ValidationProfile.from_specification('CSIP')
         profile.validate(str(files(TEST_RES_XML).joinpath(METS_VALID)))


### PR DESCRIPTION
- Always validating common rules first
- If package type is in rules implemented by validator later validation is perform against specific 'oaispackagetype'