### PR TITLE
Specification v2.0.4 - missing DIP and CSIP rules

### DIFF
--- a/eark_validator/ipxml/resources/schematron/V2.0.4/CSIP/mets_structMap_rules.xml
+++ b/eark_validator/ipxml/resources/schematron/V2.0.4/CSIP/mets_structMap_rules.xml
@@ -16,9 +16,14 @@
     <rule context="/mets:mets/mets:structMap[@LABEL = 'CSIP']/mets:div">
       <assert id="CSIP85" role="ERROR" test="@ID">An xml:id identifier must be unique within the package.</assert>
       <assert id="CSIP88" role="ERROR" test="mets:div[@LABEL = 'Metadata']">The metadata referenced in the administrative and/or descriptive metadata section is described in the structural map with one sub division.</assert>
+      <assert id="CSIP90" role="ERROR" test="mets:div[@LABEL = 'Metadata']">The metadata division div element's @LABEL attribute value must be "Metadata".</assert>
       <assert id="CSIP93" role="WARN" test="mets:div[@LABEL = 'Documentation']">The documentation referenced in the file section file groups is described in the structural map with one sub division.</assert>
+      <assert id="CSIP95" role="ERROR" test="mets:div[@LABEL = 'Documentation']">The documentation division div element in the package uses the value "Documentation" from the vocabulary as the value for the @LABEL attribute.</assert>
       <assert id="CSIP97" role="WARN" test="mets:div[@LABEL = 'Schemas']">The schemas referenced in the file section file groups are described in the structural map within a single sub-division.</assert>
+      <assert id="CSIP99" role="ERROR" test="mets:div[@LABEL = 'Schemas']">The schema division div element's @LABEL attribute has the value Schemas from the vocabulary.</assert>
       <assert id="CSIP101" role="WARN" test="mets:div[@LABEL = 'Representations']">When no representations are present the content referenced in the file section file group with @USE attribute value “Representations” is described in the structural map as a single sub division.</assert>
+      <assert id="CSIP103" role="ERROR" test="mets:div[@LABEL = 'Representations']">The package's content division div element must have the @LABEL attribute value "Representations", taken from the vocabulary.</assert>
+      <assert id="CSIP105" role="WARN" test="mets:div[@LABEL = 'Representations']/mets:div">When a package consists of multiple representations, each described by a representation level METS.xml document, there should be a discrete representation div element for each representation.</assert>
     </rule>
     <rule context="/mets:mets/mets:structMap[@LABEL = 'CSIP']/mets:div/mets:div[@LABEL = 'Metadata']">
       <assert id="CSIP89" role="ERROR" test="@ID">An xml:id identifier must be unique within the package.</assert>

--- a/eark_validator/ipxml/resources/schematron/V2.0.4/DIP/mets_dmdSec_rules.xml
+++ b/eark_validator/ipxml/resources/schematron/V2.0.4/DIP/mets_dmdSec_rules.xml
@@ -4,5 +4,8 @@
   <ns prefix="xlink" uri="http://www.w3.org/1999/xlink" />
   <pattern id="METS_descriptive_metadata_element">
     <title>Use of the METS descriptive metadata section.</title>
+    <rule context="/mets:mets/mets:dmdSec">
+      <assert id="DIP4" role="WARN" test="@STATUS = 'CURRENT'">Indicates the status of the package using a fixed vocabulary. The status SHOULD in a DIP be set to "CURRENT".</assert>
+    </rule>
   </pattern>
 </schema>

--- a/eark_validator/ipxml/resources/schematron/V2.0.4/DIP/mets_metsHdr_rules.xml
+++ b/eark_validator/ipxml/resources/schematron/V2.0.4/DIP/mets_metsHdr_rules.xml
@@ -3,5 +3,8 @@
   <ns prefix="csip" uri="https://DILCIS.eu/XML/METS/CSIPExtensionMETS"/>
   <pattern id="METS_header_element">
     <title>Use of the METS header</title>
+    <rule context="/mets:mets/mets:metsHdr">
+      <assert id="DIP3" role="ERROR" test="@csip:OAISPACKAGETYPE = 'DIP'">The in CSIP added attribute `@csip:OAISPACKAGETYPE` is used with the value "DIP".</assert>
+    </rule>
   </pattern>
 </schema>

--- a/eark_validator/ipxml/resources/schematron/V2.0.4/DIP/mets_metsRootElement_rules.xml
+++ b/eark_validator/ipxml/resources/schematron/V2.0.4/DIP/mets_metsRootElement_rules.xml
@@ -4,5 +4,9 @@
   <ns prefix="sip" uri="https://DILCIS.eu/XML/METS/SIPExtensionMETS"/>
   <pattern id="METS_root_element">
       <title>Validate METS root element.</title>
+      <rule context="/mets:mets">
+        <assert id="DIP1" role="ERROR" test="@OBJID">The mets/@OBJID attribute is mandatory, its value is a string identifier for the METS document. Note that the value of the `mets/@OBJID attribute` for the DIP is expected to be different from the SIP and AIP to reflect the creation of a new package.</assert>
+        <assert id="DIP2" role="ERROR" test="starts-with(@PROFILE, 'https://earkdip.dilcis.eu/profile/E-ARK-DIP'">The mets/@PROFILE attribute MUST contain the URL of the METS profile that the information package conforms with.</assert>
+      </rule>
   </pattern>
 </schema>


### PR DESCRIPTION
Added missing rules for specification version 2.0.4.

- Missing DIP rules are the same as in version 2.1.0
- Missing CSIP rules are almost the same as in version 2.1.0