### PR TITLE
FIX: Replace invalid JSON schema types

### DIFF
--- a/eark_validator/infopacks/manifest.py
+++ b/eark_validator/infopacks/manifest.py
@@ -97,7 +97,7 @@ class ManifestEntries:
             algorithm: ChecksumAlg = ChecksumAlg.from_string(checksum_algorithm)
         checksums = [ Checksummer.from_file(abs_path, algorithm) ] if checksum_algorithm else []
         return ManifestEntry.model_validate({
-            'path': entry_path,
+            'path': str(entry_path),
             'size': os.path.getsize(abs_path),
             'checksums': checksums
             })
@@ -167,7 +167,7 @@ class Manifests:
                                                    entry_path,
                                                    checksum_algorithm=checksum_algorithm))
         return Manifest.model_validate({
-            'root': path,
+            'root': str(path),
             'source': SourceType.PACKAGE,
             'summary': None,
             'entries': entries
@@ -182,7 +182,7 @@ class Manifests:
         entries: list[ManifestEntry] = list(map(ManifestEntries.from_file_entry,
                                                 mets_file.file_entries))
         return Manifest.model_validate({
-            'root': path,
+            'root': str(path),
             'source': SourceType.METS,
             'summary': None,
             'entries': entries
@@ -198,8 +198,9 @@ def _test_checksums(path: Path, checksums: list[Checksum]) -> list[str]:
     return issues
 
 def _resolve_manifest_root(manifest: Manifest) -> Path:
+    root: Path = Path(manifest.root)
     if manifest.source == SourceType.PACKAGE:
-        return manifest.root
+        return root
     if manifest.source == SourceType.METS:
-        return manifest.root.parent
+        return root.parent
     raise ValueError(f'Unknown source type {manifest.source}')

--- a/eark_validator/model/manifest.py
+++ b/eark_validator/model/manifest.py
@@ -33,7 +33,7 @@ from .checksum import Checksum
 from .constants import METS, UNKNOWN, PACKAGE # pylint: disable=W0611
 
 class ManifestEntry(BaseModel):
-    path : Path | str
+    path : str
     size : int = 0
     checksums : List[Checksum] = []
 
@@ -52,7 +52,7 @@ class SourceType(str, Enum):
 
 class Manifest(BaseModel):
     source: SourceType = SourceType.UNKNOWN
-    root: Path
+    root: str
     summary: Optional[ManifestSummary] = None
     entries: List[ManifestEntry] = []
 

--- a/eark_validator/model/metadata.py
+++ b/eark_validator/model/metadata.py
@@ -24,7 +24,6 @@
 # under the License.
 #
 from enum import Enum
-from pathlib import Path
 from typing import Annotated, List
 
 from pydantic import BaseModel, StringConstraints
@@ -37,7 +36,7 @@ class EntryType(str, Enum):
     METADATA = 'metadata'
 
 class FileEntry(BaseModel):
-    path : Path | str
+    path : str
     type: EntryType = EntryType.FILE
     size : int = 0
     checksum : Checksum

--- a/eark_validator/model/validation_report.py
+++ b/eark_validator/model/validation_report.py
@@ -30,8 +30,8 @@ E-ARK : Information Package Validation
 """
 
 from enum import Enum, unique
-from typing import Any, List, Optional
-import uuid
+from typing import Any, List, Optional, Annotated
+from uuid import uuid4
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
@@ -139,7 +139,7 @@ class MetatdataResultSet(BaseModel):
     schematron_results: MetadataResults = Field(validation_alias='schematronResults')
 
 class ValidationReport(BaseModel):
-    uid: uuid.UUID = uuid.uuid4()
+    uid: Annotated[str, Field(default_factory=lambda: uuid4().hex)]
     structure: Optional[StructResults] = None
     metadata: Optional[MetatdataResultSet] = None
     package: Optional[InformationPackage] = None

--- a/tests/manifests_test.py
+++ b/tests/manifests_test.py
@@ -175,7 +175,7 @@ class ManifestEntryTest(unittest.TestCase):
         entry: ManifestEntry = ManifestEntries.from_file_entry(_parse_file_entry(ET.fromstring(FILE_XML)))
         self.assertEqual(entry.checksums[0].algorithm, ChecksumAlg.SHA256)
         self.assertEqual(entry.checksums[0].value, 'F37E90511B5DDE2E9C60378A0F0A0A1CF07145C8F12651E0E19731892C608DA7')
-        self.assertEqual(entry.path, 'representations/rep1/METS.xml')
+        self.assertEqual(str(entry.path), 'representations/rep1/METS.xml')
         self.assertEqual(entry.size, 3554)
 
 class ManifestTest(unittest.TestCase):
@@ -255,7 +255,7 @@ class ManifestTest(unittest.TestCase):
 
     def test_resolve_manifest_bad_source(self):
         manifest = Manifest.model_validate({
-            'root': Path(files(UNPACKED).joinpath('733dc055-34be-4260-85c7-5549a7083031')),
+            'root': str(files(UNPACKED).joinpath('733dc055-34be-4260-85c7-5549a7083031')),
             'source': SourceType.UNKNOWN
             })
         with self.assertRaises(ValueError):


### PR DESCRIPTION
- use of `Path` and `uuid` in model types yields an invalid JSON schema;
- replaced both types in model classes with `str`;
- added `str(path)` and hex representation of `uuid` in the respective classes; and
- fixed tests.