### PR TITLE
Support only for python 3.12

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["pypy3.10", "3.10", "3.11", "3.12"]
+        python-version: ["3.12", "3.13"]
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.12", "3.13"]
+        python-version: ["3.12"]
 
     steps:
     - uses: actions/checkout@v3

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ website of the Digital Information LifeCycle Interoperability Standards Board (D
 
 ### Pre-requisites
 
-Python 3.10 or later is required to run the E-ARK Python Information Package Validator.
+Python 3.12 or later is required to run the E-ARK Python Information Package Validator.
 
 You must be running either a Debian/Ubuntu Linux distribution or Windows Subsystem for Linux on Windows to follow these commands.
 If you are running a different Linux distribution you must change the apt commands to your package manager.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ website of the Digital Information LifeCycle Interoperability Standards Board (D
 
 ### Pre-requisites
 
-Python 3.12 or later is required to run the E-ARK Python Information Package Validator.
+Python 3.12 is required to run the E-ARK Python Information Package Validator.
 
 You must be running either a Debian/Ubuntu Linux distribution or Windows Subsystem for Linux on Windows to follow these commands.
 If you are running a different Linux distribution you must change the apt commands to your package manager.


### PR DESCRIPTION
Removing testing with older versions of Python, as the library we use requires Python >=3.12 - https://github.com/E-ARK-Software/eark-validator/pull/127