### PR TITLE
Optional output file path option

### DIFF
--- a/eark_validator/cli/app.py
+++ b/eark_validator/cli/app.py
@@ -143,7 +143,7 @@ def _validate_ip(path: str, version: SpecificationVersion, output_path: Optional
 
     output = report.model_dump_json()
     if output_path is not None:
-        with open(output_path, "w") as text_file:
+        with open(output_path, 'w') as text_file:
             text_file.write(output)
         print(f"Detiled output saved in {output_path}")
     else:

--- a/eark_validator/cli/app.py
+++ b/eark_validator/cli/app.py
@@ -95,6 +95,12 @@ def parse_command_line():
                         type=SpecificationVersion,
                         choices=list(SpecificationVersion),
                         help='Specification version used for validation. Default is %(default)s.')
+    PARSER.add_argument('-o', '--output_path',
+                        nargs='?',
+                        dest='output_path',
+                        default=None,
+                        type=str,
+                        help='Path to file where output will be saved')
     PARSER.add_argument('--version',
                         action='version',
                         version=__version__)
@@ -124,18 +130,24 @@ def main():
 
     # Iterate the file arguments
     for file_arg in args.files:
-        _loop_exit, _ = _validate_ip(file_arg, args.specification_version)
+        _loop_exit, _ = _validate_ip(file_arg, args.specification_version, args.output_path)
         _exit = _loop_exit if (_loop_exit > 0) else _exit
     sys.exit(_exit)
 
-def _validate_ip(path: str, version: SpecificationVersion) -> Tuple[int, Optional[ValidationReport]]:
+def _validate_ip(path: str, version: SpecificationVersion, output_path: Optional[str]) -> Tuple[int, Optional[ValidationReport]]:
     ret_stat, checked_path = _check_path(path)
     if ret_stat > 0:
         return ret_stat, None
     report = PACKAGES.PackageValidator(checked_path, version).validation_report
     print(f'Path {checked_path}, struct result is: {report.structure.status.value}')
-    # for message in report.structure.messages:
-    print(report.model_dump_json())
+
+    output = report.model_dump_json()
+    if output_path is not None:
+        with open(output_path, "w") as text_file:
+            text_file.write(output)
+        print(f"Detiled output saved in {output_path}")
+    else:
+        print(output)
 
     return ret_stat, report
 


### PR DESCRIPTION
Option to write json output to the specified file instead of printing.
Makes sense when only 1 path is given to check.
